### PR TITLE
Restructure for autocomplete fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,14 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+# Ignore emacs temp files
+
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,4 +21,7 @@
 //= require hyrax
 //= require almond
 //= require authority_select
-//= require subject
+
+//= require creator
+//= require contributor
+

--- a/app/assets/javascripts/authority_select.es6
+++ b/app/assets/javascripts/authority_select.es6
@@ -20,9 +20,9 @@ export class AuthoritySelect {
 	$(selectBox).on('change', function (data) {
 	    var selectBoxValue = $(this).val();
 	    $(inputField).each(function (data) { $(this).data('autocomplete-url', selectBoxValue);
-				
+						 
 					       });
-	    Hyrax.autocomplete();
+	    setupAutocomplete();
 	});
     }
     /**
@@ -32,10 +32,11 @@ export class AuthoritySelect {
 	var selectBox = this.selectBox;
 	var inputField = this.inputField;
 	
+	
 	var observer = new MutationObserver(function (mutations) {
 	    mutations.forEach(function (mutation) {
 		$(inputField).each(function (data) { $(this).data('autocomplete-url', $(selectBox).val()) });
-		Hyrax.autocomplete();
+		setupAutocomplete();
 	    });
 	});
 
@@ -43,12 +44,32 @@ export class AuthoritySelect {
 	observer.observe(document.body, config);
     }
 
-   /**
-    * Initialize bindings
-    */
+    
+
+    /**
+     * Initialize bindings
+     */
     initialize() {
 	this.selectBoxChange();
 	this.observeAddedElement();
+	setupAutocomplete();
     }
 }
 
+/**
+ * intialize the Hyrax autocomplete with the fields that you are using
+ */
+function setupAutocomplete() {
+    var Autocomplete = require('hyrax/autocomplete');
+    var autocomplete = new Autocomplete({
+	"autocompleteFields":
+	["creator","contributor"]
+    });
+
+    $('.multi_value.form-group').manage_fields({
+        add: function(e, element) {
+	    autocomplete.fieldAdded(element);
+        }
+    });
+    autocomplete.setup();
+};

--- a/app/assets/javascripts/contributor.js
+++ b/app/assets/javascripts/contributor.js
@@ -1,0 +1,5 @@
+Blacklight.onLoad( function() {
+	var authoritySelect = require('authority_select');
+	var as = new authoritySelect.AuthoritySelect({ selectBox : "#work_contributor_authorities", inputField : "input.work_contributor" });
+	as.initialize();
+});

--- a/app/assets/javascripts/contributor_authority_select.js
+++ b/app/assets/javascripts/contributor_authority_select.js
@@ -1,0 +1,5 @@
+$('document').ready(function() {
+    if ($("[name='work[contributor_authorities]").length) {
+	authoritySelect({ select : "[name='work[contributor_authorities]']", input : "[name='work[contributor][]']" });
+    }
+});

--- a/app/assets/javascripts/creator.js
+++ b/app/assets/javascripts/creator.js
@@ -1,0 +1,5 @@
+Blacklight.onLoad( function() {
+	var authoritySelect = require('authority_select');
+	var as = new authoritySelect.AuthoritySelect({ selectBox : "#work_creator_authorities", inputField : "input.work_creator" });
+	as.initialize();
+});

--- a/app/assets/javascripts/creator_authority_select.js
+++ b/app/assets/javascripts/creator_authority_select.js
@@ -1,0 +1,5 @@
+$('document').ready(function() {
+    if ($("[name='work[authorities]").length) {
+	authoritySelect({ select : "[name='work[creator_authorities]']", input : "[name='work[creator][]']" });
+    }
+});

--- a/app/assets/javascripts/subject.js
+++ b/app/assets/javascripts/subject.js
@@ -1,7 +1,0 @@
-$("document").ready(function() {
-    if ($("[name='work[authorities]").length) {
-	var authoritySelect = require('authority_select');
-	var as = new authoritySelect.AuthoritySelect({ selectBox : "[name='work[authorities]']", inputField : "[name='work[subject][]']" });
-	as.initialize();
-    }
-});

--- a/app/forms/hyrax/work_form.rb
+++ b/app/forms/hyrax/work_form.rb
@@ -2,14 +2,34 @@
 #  `rails generate hyrax:work Work`
 module Hyrax
   class WorkForm < Hyrax::Forms::WorkForm
-
-    attr_writer :authorities
+    attr_writer :creator_authorities
+    attr_writer :contributor_authorities
     
     self.model_class = ::Work
     self.terms += [:resource_type]
-   
+
     def authorities
       @authorities = Rails.application.config_for(:authorities)
+    end
+    
+    def subject_authorities
+      self.authorities
+    end
+
+    def creator_authorities
+      self.authorities
+    end
+
+    def contributor_authorities
+      self.authorities
+    end
+
+    def creator_authorities
+      self.authorities
+    end
+
+    def contributor_authorities
+      self.authorities
     end
 
   end

--- a/app/views/records/edit_fields/_contributor.html.erb
+++ b/app/views/records/edit_fields/_contributor.html.erb
@@ -1,0 +1,13 @@
+<%=
+  f.input key,
+  as: :multi_value,
+  input_html: {
+  class: 'form-control',
+  data: { 'autocomplete-url' => "/authorities/search/loc/subjects",
+'autocomplete' => key }
+} ,
+required: f.object.required?(key) %>
+
+<%= f.input :contributor_authorities, collection: f.object.contributor_authorities, prompt: "Select an authority", label: false %>
+
+

--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -8,6 +8,5 @@
 } ,
 required: f.object.required?(key) %>
 
-<%= f.input :authorities, collection: f.object.authorities, prompt: "Select an authority", label: false %>
-
+<%= f.input :creator_authorities, collection: f.object.creator_authorities, prompt: "Select an authority", label: false %>
 


### PR DESCRIPTION
Switch autocomplete select to creator/contributor from subject

Ignore emacs temp files

Remove custom subject edit field

Moving subject autocomplete funtionality to creator/contributor

creator/contributor

Restructure for autocomplete fields

Added private method to reactivate the autocomplete with chosen fields

Restructure for autocomplete fields

Fix typo in form