### PR TITLE
Switch to QaSelectService pattern for select boxes

### DIFF
--- a/app/forms/hyrax/work_form.rb
+++ b/app/forms/hyrax/work_form.rb
@@ -2,35 +2,7 @@
 #  `rails generate hyrax:work Work`
 module Hyrax
   class WorkForm < Hyrax::Forms::WorkForm
-    attr_writer :creator_authorities
-    attr_writer :contributor_authorities
-    
     self.model_class = ::Work
     self.terms += [:resource_type]
-
-    def authorities
-      @authorities = Rails.application.config_for(:authorities)
-    end
-    
-    def subject_authorities
-      self.authorities
-    end
-
-    def creator_authorities
-      self.authorities
-    end
-
-    def contributor_authorities
-      self.authorities
-    end
-
-    def creator_authorities
-      self.authorities
-    end
-
-    def contributor_authorities
-      self.authorities
-    end
-
   end
 end

--- a/app/services/hyrax/name_authorities.rb
+++ b/app/services/hyrax/name_authorities.rb
@@ -1,0 +1,8 @@
+module Hyrax
+  # Provide select options for the copyright status (edm:rights) field
+  class NameAuthorities < QaSelectService
+    def initialize
+      super('names')
+    end
+  end
+end

--- a/app/views/records/edit_fields/_contributor.html.erb
+++ b/app/views/records/edit_fields/_contributor.html.erb
@@ -1,3 +1,5 @@
+<% name_authorities = Hyrax::NameAuthorities.new %>
+
 <%=
   f.input key,
   as: :multi_value,
@@ -8,4 +10,4 @@
 } ,
 required: f.object.required?(key) %>
 
-<%= f.input :contributor_authorities, collection: f.object.contributor_authorities, prompt: "Select an authority", label: false %>
+<%= f.input key, collection: name_authorities.select_active_options, label: false %>

--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -1,3 +1,5 @@
+<% name_authorities = Hyrax::NameAuthorities.new %>
+
 <%=
   f.input key,
   as: :multi_value,
@@ -8,5 +10,5 @@
 } ,
 required: f.object.required?(key) %>
 
-<%= f.input :creator_authorities, collection: f.object.creator_authorities, prompt: "Select an authority", label: false %>
+<%= f.input key, collection: name_authorities.select_active_options, label: false %>
 

--- a/config/authorities.yml
+++ b/config/authorities.yml
@@ -1,6 +1,0 @@
-development:	
-     "Library of Congress Names" : '/authorities/search/loc/names'
-     "FAST" : '/authorities/search/assign_fast/all'
-production:	
-     "Library of Congress Names" : '/authorities/search/loc/names'
-     "FAST" : '/authorities/search/assign_fast/all'

--- a/config/authorities/names.yml
+++ b/config/authorities/names.yml
@@ -1,0 +1,7 @@
+terms:
+    - id: /authorities/search/loc/names
+      term: LOC Names
+      active: true
+    - id: /authorities/search/assign_fast/all
+      term: FAST
+      active: true


### PR DESCRIPTION
I was implementing yaml config to select box functionality, but this already existed as 
QaSelectService this removes all my yaml code and uses the service.